### PR TITLE
model: package: add @destdir attribute

### DIFF
--- a/core/model/package.go
+++ b/core/model/package.go
@@ -27,6 +27,7 @@ const (
 	Package_Key_InstallPrefix = "install-prefix"
 	Package_Key_StatDir       = "@statdir"
 	Package_Key_Parallel      = "parallel"
+	Package_Key_Destdir       = "@destdir"
 
 	Package_Default_BuildDir = "__BUILD"
 )
@@ -152,6 +153,10 @@ func (pkg Package) GetStatDir() string {
 
 func (pkg Package) GetParallel() int {
 	return pkg.GetInt(Package_Key_Parallel, 0)
+}
+
+func (pkg Package) GetDestdir() string {
+	return pkg.GetStr(Package_Key_Destdir)
 }
 
 func LoadPackageYaml(fn string, name string) (*Package, error) {

--- a/doc/package.md
+++ b/doc/package.md
@@ -34,3 +34,4 @@ These keys are automatically filled in by MPBT and should not be overwritten.
 | `@PROJECT`      | link to the global project config object                                        |
 | `@SOLUTION`     | link to the global solution config object                                       |
 | `@statdir`      | directory for MPBT status files                                                 |
+| `@destdir`      | DESTDIR prefix, if install should go to a staging area                          |


### PR DESCRIPTION
This attribute is supposed to be filled by a workflow and honored by builder backends, in order to install under a given DESTDIR prefix instead of the running system. Preparation for packaging support.